### PR TITLE
Draft #5 of SRFI 255

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 usage () {
-        printf 'Usage: %s chez\n' "$(basename $0)" 1>&2
+        printf 'Usage: %s SCHEME-KEYWORD\n' "$(basename $0)" 1>&2
+        printf 'Supported SCHEME-KEYWORDs: chez, guile\n' 1>&2
         exit 1
 }
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -308,7 +308,7 @@ the condition types <code>&amp;who</code> or
        (with-exception-handler
         (lambda (con)
           (raise-continuable
-           (if (condition? con)
+           (if ((restarter-condition-predicate val-restarter) con)
                (condition con val-restarter)
                con)))
         (lambda () (/ x y)))))))

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -429,8 +429,6 @@ appears in more than one clause.</p>
 
 <h5>Semantics:</h5>
 
-<!-- TODO: Update for conditional restarting (pred-expression). -->
-
 <p>First, the <var class="syn">pred-expression</var>s are evaluated
 to <a href="#condition-predicate">condition predicates</a> in an
 unspecified order. Then, an exception handler

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -398,15 +398,13 @@ in user code.</p>
 
 <h5>Syntax:</h5>
 
-<!-- FIXME: 'body' occurs in two different subforms. -->
-
 <p><var class="syn">restarter-clauses</var> takes one of two forms,
 either</p>
 
 <pre><code>(((</code><var class="syn">tag</var> <code>.</code> <var class="syn">formals</var><code>)</code>
   <var class="syn">description</var>
   <var class="syn">pred-expression</var>
-  <var class="syn">body</var><code>) …)</code></pre>
+  <var class="syn">restarter-body</var><code>) …)</code></pre>
 
 <p>or</p>
 
@@ -414,7 +412,7 @@ either</p>
  <code>((</code><var class="syn">tag</var> <code>.</code> <var class="syn">formals</var><code>)</code>
   <var class="syn">description</var>
   <var class="syn">pred-expression</var>
-  <var class="syn">body</var><code>) …)</code></pre>
+  <var class="syn">restarter-body</var><code>) …)</code></pre>
 
 <p><var class="syn">who</var> must be an identifier or string.
 <var class="syn">condition-var</var> and <var class="syn">tag</var>
@@ -444,7 +442,7 @@ condition are included.
 If
 <var class="syn">condition-var</var> is provided, then the condition
 object raised by the original triggering exception is bound to it in
-each <var class="syn">body</var>.</p>
+each <var class="syn">restarter-body</var>.</p>
 
 <p>The who field of each restarter constructed from
 <var class="syn">restarter-clauses</var> is initialized to

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -464,7 +464,7 @@ violation occurs.</p>
 
 <h5>Syntax:</h5>
 
-<p><var class="syn">who</var> must be a symbol or string.</p>
+<p><var class="syn">who</var> must be an identifier or string.</p>
 
 <h5>Semantics:</h5>
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -255,17 +255,24 @@ these informational fields. In particular, a restarter constructed by
 <code>make-restarter</code> (see below) must not have the condition
 types <code>&amp;who</code> or <code>&amp;message</code>.</p>
 
-<p>When a restarter is raised in response to an exception (called the
-<dfn>triggering exception</dfn> in this document), it should be a
-composite condition (see Section 7.2.1 of the <cite>R6RS</cite>) including the
-object raised by the triggering exception as one of its components.</p>
+<p>Usually, restarters and their handlers will be constructed
+implicitly by the high-level forms described in the
+<a href="#syntax">Syntax</a> section. Restarters and restarter handlers
+must obey the following protocol:</p>
 
-<!--
-  TODO: Restarter protocol. If we are going to allow restarters
-  to be created by hand, we should expand this section to explain
-  how to write a correct restart handler. This should include
-  coverage of the condition predicate.
--->
+<ul>
+  <li>
+    <p>When a restarter is raised in response to an exception (called the
+    <dfn>triggering exception</dfn> in this document), it must be a
+    composite condition (see Section 7.2.1 of the <cite>R6RS</cite>) including the
+    object raised by the triggering exception as one of its components.</p>
+  </li>
+  <li>
+    <p>A handler must not invoke or re-raise a restarter if the object
+    raised by the triggering exception does not satisfy that restarter’s
+    condition predicate.</p>
+  </li>
+</ul>
 
 <!-- Procedures section -->
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -225,6 +225,11 @@ It has five fields:</p>
   4.1.4 of <cite>R7RS Small</cite>, describing the arguments expected by the
   restarter’s <var>invoker</var>.</dd>
 
+  <dt>condition-predicate</dt>
+  <dd>A procedure which returns true when applied to a condition object
+  <var>c</var> when the restarter can be used to restart the computation
+  that raised <var>c</var>. Otherwise, it returns <code>#f</code>.</dd>
+
   <dt>invoker</dt>
   <dd>A procedure that actually performs the recovery. It must not
   return. The number of arguments it expects is given by
@@ -239,6 +244,7 @@ It has five fields:</p>
   (description restarter-description)
   (who restarter-who)
   (formals restarter-formals)
+  (condition-predicate restarter-condition-predicate)
   (invoker restarter-invoker))</code></pre>
 
 <p>A restarter’s fields
@@ -254,12 +260,20 @@ types <code>&amp;who</code> or <code>&amp;message</code>.</p>
 composite condition (see Section 7.2.1 of the <cite>R6RS</cite>) including the
 object raised by the triggering exception as one of its components.</p>
 
+<!--
+  TODO: Restarter protocol. If we are going to allow restarters
+  to be created by hand, we should expand this section to explain
+  how to write a correct restart handler. This should include
+  coverage of the condition predicate.
+-->
+
 <!-- Procedures section -->
 
 <h3 id="procedures">Procedures</h3>
 
 <p><code>(make-restarter</code> <var>tag</var> <var>description</var>
-<var>who</var> <var>formals</var> <var>invoker</var><code>)</code> →
+<var>who</var> <var>formals</var> <var>condition-predicate</var>
+<var>invoker</var><code>)</code> →
 <span class="type-meta">restarter</span></p>
 
 <p>Returns a restarter condition with the specified fields.
@@ -282,6 +296,7 @@ the condition types <code>&amp;who</code> or
                             "Return x."
                             'safe-/
                             '(x)
+                            condition?
                             return-value)))
        (with-exception-handler
         (lambda (con)
@@ -315,6 +330,10 @@ restart[0]&gt; <samp>(return-value 4)</samp>
 
 <code>(restarter-who</code> <var>restarter</var><code>)</code> →
 <span class="type-meta">symbol-or-string</span><br>
+
+<code>(restarter-condition-predicate</code>
+<var>restarter</var><code>)</code> →
+<span class="type-meta">procedure</span><br>
 
 <code>(restarter-formals</code> <var>restarter</var><code>)</code> →
 <span class="type-meta">pair-or-symbol</span></p>
@@ -377,6 +396,7 @@ either</p>
 
 <pre><code>(((</code><var class="syn">tag</var> <code>.</code> <var class="syn">formals</var><code>)</code>
   <var class="syn">description</var>
+  <var class="syn">pred-expression</var>
   <var class="syn">body</var><code>) …)</code></pre>
 
 <p>or</p>
@@ -384,25 +404,30 @@ either</p>
 <pre><code>(</code><var class="syn">condition-var</var>
  <code>((</code><var class="syn">tag</var> <code>.</code> <var class="syn">formals</var><code>)</code>
   <var class="syn">description</var>
+  <var class="syn">pred-expression</var>
   <var class="syn">body</var><code>) …)</code></pre>
 
 <p><var class="syn">who</var> must be an identifier or string.
 <var class="syn">condition-var</var> and <var class="syn">tag</var>
 are identifiers. <var class="syn">formals</var> is a formals list
 as specified in Section 4.1.4 of the <cite>R7RS</cite>.
-<var class="syn">description</var> is a string.</p>
+<var class="syn">description</var> is a string.
+<var class="syn">pred-expression</var> is an expression that must
+evaluate to a predicate (<cite>R7RS</cite> §6.1).</p>
 
 <p>A syntax error is signaled if any <var class="syn">tag</var>
 appears in more than one clause.</p>
 
 <h5>Semantics:</h5>
 
+<!-- TODO: Update for conditional restarting (pred-expression). -->
+
 <p>Installs a new exception handler for the dynamic extent (as
 determined by <code>dynamic-wind</code>) of the invocation of
 <var class="syn">body</var>. If an exception occurs, this handler
 constructs a compound restarter condition, which includes the condition
 raised by the triggering exception and
-restarters constructed from the <var class="syn">restarter-clauses</var>,
+restarters constructed from the <var class="syn">restarter-clauses</var>.
 and raises it with <code>raise-continuable</code>. If
 <var class="syn">condition-var</var> is provided, then the condition
 object raised by the original triggering exception is bound to it in
@@ -429,12 +454,15 @@ by the triggering exception.</p>
   (restarter-guard safe-/
     (con ((return-value v)
           "Return a specific value."
+          assertion-violation?
           v)
          ((return-numerator)
           "Return the numerator."
+          assertion-violation?
           a)
          ((return-zero)
           "Return zero."
+          assertion-violation?
           0))
     (/ a b)))
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -432,7 +432,7 @@ determined by <code>dynamic-wind</code>) of the invocation of
 <var class="syn">body</var>. If an exception occurs, this handler
 constructs a compound restarter condition, which includes the condition
 raised by the triggering exception and
-restarters constructed from the <var class="syn">restarter-clauses</var>.
+restarters constructed from the <var class="syn">restarter-clauses</var>,
 and raises it with <code>raise-continuable</code>. Only restarters
 whose condition predicates return true when applied to the raised
 condition are included.

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -225,7 +225,7 @@ It has five fields:</p>
   4.1.4 of <cite>R7RS Small</cite>, describing the arguments expected by the
   restarter’s <var>invoker</var>.</dd>
 
-  <dt>condition-predicate</dt>
+  <dt id="condition-predicate">condition-predicate</dt>
   <dd>A procedure which returns true when applied to a condition object
   <var>c</var> when the restarter can be used to restart the computation
   that raised <var>c</var>. Otherwise, it returns <code>#f</code>.</dd>
@@ -391,6 +391,8 @@ in user code.</p>
 
 <h5>Syntax:</h5>
 
+<!-- FIXME: 'body' occurs in two different subforms. -->
+
 <p><var class="syn">restarter-clauses</var> takes one of two forms,
 either</p>
 
@@ -422,20 +424,28 @@ appears in more than one clause.</p>
 
 <!-- TODO: Update for conditional restarting (pred-expression). -->
 
-<p>Installs a new exception handler for the dynamic extent (as
+<p>First, the <var class="syn">pred-expression</var>s are evaluated
+to <a href="#condition-predicate">condition predicates</a> in an
+unspecified order. Then, an exception handler
+is installed for the dynamic extent (as
 determined by <code>dynamic-wind</code>) of the invocation of
 <var class="syn">body</var>. If an exception occurs, this handler
 constructs a compound restarter condition, which includes the condition
 raised by the triggering exception and
 restarters constructed from the <var class="syn">restarter-clauses</var>.
-and raises it with <code>raise-continuable</code>. If
+and raises it with <code>raise-continuable</code>. Only restarters
+whose condition predicates return true when applied to the raised
+condition are included.
+If
 <var class="syn">condition-var</var> is provided, then the condition
 object raised by the original triggering exception is bound to it in
 each <var class="syn">body</var>.</p>
 
 <p>The who field of each restarter constructed from
 <var class="syn">restarter-clauses</var> is initialized to
-<var class="syn">who</var>.
+<var class="syn">who</var>, and
+the condition-predicate field to the value of
+<var class="syn">pred-expression</var>.
 Each invoker is constructed
 from the <var class="syn">expressions</var>; when it is invoked, the
 values of the final <var class="syn">expression</var> are delivered

--- a/srfi/:255.sls
+++ b/srfi/:255.sls
@@ -31,6 +31,7 @@
           restarter-formals
           restarter-description
           restarter-invoker
+          restarter-condition-predicate
           restarter-who
           define-restartable
           restarter-guard

--- a/srfi/:255/restarters.sls
+++ b/srfi/:255/restarters.sls
@@ -205,7 +205,7 @@
                               (apply values vals))))))))))))))))))
 
   (define-syntax restartable
-    (syntax-rules ()
+    (syntax-rules (lambda)
      ((_ (x ...) . _)
       (syntax-violation 'restartable
                         "who must be an identifier or string"

--- a/srfi/:255/restarters.sls
+++ b/srfi/:255/restarters.sls
@@ -31,6 +31,7 @@
           restarter-formals
           restarter-description
           restarter-invoker
+          restarter-condition-predicate
           restarter-who
           restart
           define-restartable

--- a/tests/test-restarters.scm
+++ b/tests/test-restarters.scm
@@ -139,7 +139,7 @@
   (lambda ()
     (define-restartable (f x)
       (if (not x)
-          (error 'f "false")
+          (assertion-violation 'f "false")
           x))
     (f #f))))
 
@@ -150,7 +150,7 @@
   (lambda ()
     (define-restartable (f . xs)
       (if (null? xs)
-          (error 'f "empty")
+          (assertion-violation 'f "empty")
           xs))
     (f))))
 
@@ -161,7 +161,7 @@
     (define-restartable f
       (lambda (x)
         (if (not x)
-            (error 'f "false")
+            (assertion-violation 'f "false")
             x)))
     (f #f))))
 
@@ -172,7 +172,7 @@
   (lambda ()
     (define-restartable (f x . rest)
       (if (null? rest)
-          (error 'f "empty rest parameter")
+          (assertion-violation 'f "empty rest parameter")
           (list x rest)))
     (f 1))))
 
@@ -184,7 +184,7 @@
     (map (restartable
           "anonymous"
           (lambda (x)
-	    (if x (+ x 1) (error 'no-one "false"))))
+	    (if x (+ x 1) (assertion-violation 'no-one "false"))))
 	 '(1 2 #f 4)))))
 
 (test-equal "restartable 2 (variadic)"
@@ -195,7 +195,7 @@
     ((restartable "test"
                   (lambda xs
                     (if (null? xs)
-                        (error 'test "empty")
+                        (assertion-violation 'test "empty")
                         xs)))))))
 
 (test-equal "restartable 3 (polyvariadic)"
@@ -206,7 +206,7 @@
     ((restartable "test"
                   (lambda (x . rest)
                     (if (null? rest)
-                        (error 'test "empty")
+                        (assertion-violation 'test "empty")
                         (list x rest))))
      0))))
 


### PR DESCRIPTION
This draft adds a predicate to the restarter type which can be used to fine-tune which conditions a given restarter can restart. While I regret the added complexity, I believe this greater level of control was already implied by `restartable`, which only restarts assertion violations.