### PR TITLE
Draft #6

### DIFF
--- a/srfi-255.html
+++ b/srfi-255.html
@@ -254,6 +254,7 @@ types <code>&amp;who</code> or <code>&amp;message</code>.</p>
 <p>Usually, restarters and their handlers will be constructed
 implicitly by the high-level forms described in the
 <a href="#syntax">Syntax</a> section. Restarters and restarter handlers
+<!-- What is a restarter handler? -->
 must obey the following protocol:</p>
 
 <ul>
@@ -263,8 +264,9 @@ must obey the following protocol:</p>
     composite condition (see Section 7.2.1 of the <cite>R6RS</cite>) including the
     object raised by the triggering exception as one of its components.</p>
   </li>
+  <!-- FIXME: Is this requirement bogus? -->
   <li>
-    <p>A handler must not invoke or re-raise a restarter if the object
+    <p>A handler must not invoke a restarter if the object
     raised by the triggering exception does not satisfy that restarter’s
     condition predicate.</p>
   </li>

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -534,9 +534,9 @@ of the restarter is filled by <var class="syn">who</var>.</p>
 <h5>Examples:</h5>
 
 <pre class="example"><code>&gt;</code> <samp>(with-current-interactor
-    (lambda ()
-      (map (restartable "divider" (lambda (x) (/ 10 x)))
-           '(1 2 0 4))))</samp>
+   (lambda ()
+     (map (restartable "divider" (lambda (x) (/ 10 x)))
+          '(1 2 0 4))))</samp>
 
 <code>Restartable exception occurred.
 (use-arguments . args) [divider]: Apply the procedure to new arguments.
@@ -557,10 +557,10 @@ restart[0]&gt;</code> <samp>(use-arguments 3)</samp>
     (map (restartable proc-who proc) lis)))
 
 &gt;</code> <samp>(with-current-interactor
-    (lambda ()
-      (map-restartable "divider"
-                       (lambda (x) (/ 10 x)))
-                       '(1 2 0 4))))</samp>
+   (lambda ()
+     (map-restartable "divider"
+                      (lambda (x) (/ 10 x)))
+                      '(1 2 0 4))))</samp>
 
 <code>Restartable exception occurred.
 (use-arguments . args) [divider]: Apply the procedure to new arguments.
@@ -570,10 +570,10 @@ restart[0]&gt;</code> <samp>(use-list '(#f))</samp>
   ⇒ (#f)
 
 <code>&gt;</code> <samp>(with-current-interactor
-    (lambda ()
-      (map-restartable "divider"
-                       (lambda (x) (/ 10 x)))
-                       '(1 2 0 4))))</samp>
+   (lambda ()
+     (map-restartable "divider"
+                      (lambda (x) (/ 10 x)))
+                      '(1 2 0 4))))</samp>
 
 <code>Restartable exception occurred.
 (use-arguments . args) [divider]: Apply the procedure to new arguments.

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -312,8 +312,7 @@ the condition types <code>&amp;who</code> or
                con)))
         (lambda () (/ x y)))))))
 
-&gt; <samp>(with-exception-handler
-   default-interactor
+&gt; <samp>(with-current-interactor
    (lambda () (safe-/ 1 0)))</samp>
 
 Restartable exception occurred.
@@ -493,8 +492,7 @@ by the triggering exception.</p>
           0))
     (/ a b)))
 
-&gt; <samp>(with-exception-handler
-   default-interactor
+&gt; <samp>(with-current-interactor
    (lambda () (safe-/ 1 0)))</samp>
 
 Restartable exception occurred.
@@ -535,8 +533,7 @@ of the restarter is filled by <var class="syn">who</var>.</p>
 
 <h5>Examples:</h5>
 
-<pre class="example"><code>&gt;</code> <samp>(with-exception-handler
-    default-interactor
+<pre class="example"><code>&gt;</code> <samp>(with-current-interactor
     (lambda ()
       (map (restartable "divider" (lambda (x) (/ 10 x)))
            '(1 2 0 4))))</samp>
@@ -559,8 +556,7 @@ restart[0]&gt;</code> <samp>(use-arguments 3)</samp>
            new-lis))
     (map (restartable proc-who proc) lis)))
 
-&gt;</code> <samp>(with-exception-handler
-    default-interactor
+&gt;</code> <samp>(with-current-interactor
     (lambda ()
       (map-restartable "divider"
                        (lambda (x) (/ 10 x)))
@@ -573,8 +569,7 @@ restart[0]&gt;</code> <samp>(use-list '(#f))</samp>
 
   ⇒ (#f)
 
-<code>&gt;</code> <samp>(with-exception-handler
-    default-interactor
+<code>&gt;</code> <samp>(with-current-interactor
     (lambda ()
       (map-restartable "divider"
                        (lambda (x) (/ 10 x)))
@@ -632,8 +627,7 @@ forms:</p>
 <pre class="example"><code>(define-restartable (safe-/ x y)
   (/ x y))
 
-&gt;</code> <samp>(with-exception-handler
-   default-interactor
+&gt;</code> <samp>(with-current-interactor
    (lambda () (safe-/ 4 0)))</samp>
 
 <code>Restartable exception occurred.

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -381,9 +381,7 @@ non-normative.)</p>
 <p><code>current-interactor</code></p>
 
 <p>A <a href="https://srfi.schemers.org/srfi-39/">SRFI 39</a> parameter
-object whose value is an interactor procedure. An implementation should
-initialize <code>current-interactor</code> to a sensible default
-interactor.</p>
+object whose value is an interactor procedure.</p>
 
 <p><code>(with-current-interactor</code> <var>thunk</var><code>)</code></p>
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -451,7 +451,7 @@ whose condition predicates return true when applied to the raised
 condition are included.
 If
 <var class="syn">condition-var</var> is provided, then the condition
-object raised by the original triggering exception is bound to it in
+raised by the triggering exception is bound to it in
 each <var class="syn">restarter-body</var>.</p>
 
 <p>The who field of each restarter constructed from
@@ -459,12 +459,9 @@ each <var class="syn">restarter-body</var>.</p>
 <var class="syn">who</var>, and
 the condition-predicate field to the value of
 <var class="syn">pred-expression</var>.
-Each invoker is constructed
-from the <var class="syn">expressions</var>; when it is invoked, the
-values of the final <var class="syn">expression</var> are delivered
-to the continuation of the <code>restarter-guard</code> form. The
-restarter must preserve all of the components of the condition raised
-by the triggering exception.</p>
+Each invoker is constructed using the template
+<code>(lambda <var class="syn">formals</var>
+<var class="syn">restarter-body</var>)</code>.</p>
 
 <h5>Example:</h5>
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -379,8 +379,8 @@ non-normative.)</p>
 
 <p><code>current-interactor</code></p>
 
-<p>A <a href="https://srfi.schemers.org/srfi-39/">SRFI 39</a> parameter
-object whose value is an interactor procedure.</p>
+<p>A <a href="https://srfi.schemers.org/srfi-39/">SRFI 39</a> / R7RS
+parameter object whose value is an interactor procedure.</p>
 
 <p><code>(with-current-interactor</code> <var>thunk</var><code>)</code></p>
 
@@ -558,6 +558,7 @@ restart[0]&gt;</code> <samp>(use-arguments 3)</samp>
   (restarter-guard map-restartable
     (mcon ((use-list new-lis)
            "Return new-lis as the value of map-restartable."
+           serious-condition?
            (assert (list? new-lis))
            new-lis))
     (map (restartable proc-who proc) lis)))
@@ -687,8 +688,9 @@ itself based on
 proposal</a> by Taylor Campbell. The SRFI 255 “fork” was almost
 completely rewritten by Wolfgang Corcoran-Mathe.</p>
 
-<p>Marc Nieper-Wißkirchen came up with the original concept of the
-SRFI 255 restarter system, as well as the initial sample implementation.
+<p>Marc Nieper-Wißkirchen came up with the original concept and sample
+implementation of the
+SRFI 255 restarter system.
 His work provided the foundation for this SRFI and is gratefully
 acknowledged. (This is not meant to imply that he endorses the final
 SRFI.)</p>

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -402,7 +402,7 @@ form:</p>
 
 <h3 id="syntax">Syntax</h3>
 
-<p><code>(restarter-guard</code> <var class="syn">who</var>
+<p id="restarter-guard"><code>(restarter-guard</code> <var class="syn">who</var>
 <var class="syn">restarter-clauses</var>
 <var class="syn">body</var><code>)</code></p>
 
@@ -516,7 +516,9 @@ violation occurs.</p>
 <h5>Semantics:</h5>
 
 <p><var class="syn">expr</var> must evaluate to a procedure. The
-<code>restartable</code> form establishes a restarter with tag
+<code>restartable</code> form establishes (as if with
+<a href="#restarter-guard"><code>restarter-guard</code></a>) a
+restater with tag
 <code>use-arguments</code> for the
 dynamic extent of this procedure’s invocation. If an assertion
 violation (an exception raising a condition having type
@@ -596,7 +598,8 @@ forms:</p>
   <p>The
   <code>define-restartable</code> form defines <var class="syn">variable</var>,
   binding it to a new procedure. A restarter with tag
-  <code>use-arguments</code> is established for the
+  <code>use-arguments</code> is established (as if with
+  <a href="#restarter-guard"><code>restarter-guard</code></a>) for the
   dynamic extent of this procedure's invocation. If an assertion
   violation (an exception raising a condition having type
   <code>&amp;assertion</code> (see <cite>R6RS</cite> §7.3)) occurs during invocation,

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -172,14 +172,6 @@ that SRFI 249 provides. In contrast, SRFI 255 provides a high-level
 interface that automatically handles the messy control details.
 (Restarters can still be constructed “by hand”, if need be.)</p>
 
-<p>Since the bulk of the SRFI 249 system
-also predates the exception systems of modern Scheme, it also
-duplicates the functionality of Scheme’s exception handlers by
-introducing a “restarter stack”. This stack, as a SRFI 39 / R7RS
-parameter object, is made part of the dynamic context of a Scheme
-program. Since we use the native exception system to install and
-manage restarters, there is no need for this complication.</p>
-
 <!-- Specification section -->
 
 <h2 id="specification">Specification</h2>

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -685,13 +685,13 @@ It is in portable R6RS Scheme.</p>
 itself based on
 <a href="https://mumble.net/~campbell/proposals/restart.text">a
 proposal</a> by Taylor Campbell. The SRFI 255 “fork” was almost
-completely rewritten by Wolfgang Corcoran-Mathe and Marc
-Nieper-Wißkirchen.</p>
+completely rewritten by Wolfgang Corcoran-Mathe.</p>
 
-<p>The sample implementation was written by Marc Nieper-Wißkirchen and
-Wolfgang Corcoran-Mathe. The SRFI 249 sample implementation (on which
-the current implementation is not based) was written by Arvydas
-Silanskas and revised by Wolfgang Corcoran-Mathe.</p>
+<p>Marc Nieper-Wißkirchen came up with the original concept of the
+SRFI 255 restarter system, as well as the initial sample implementation.
+His work provided the foundation for this SRFI and is gratefully
+acknowledged. (This is not meant to imply that he endorses the final
+SRFI.)</p>
 
 <p>Thanks to John Cowan for his work on SRFI 249, and his tireless
 work on so much else in Scheme.</p>

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -122,10 +122,10 @@ how an implementation should handle restarters with identical tags?
 Consider this example:</p>
 
 <pre class="example"><code>(restarter-guard map
-  (((use xs) "Return xs." xs))
+  (((use xs) "Return xs." condition? xs))
   (map (lambda (x)
          (restarter-guard reciprocal
-           (((use y) "Return y." y))
+           (((use y) "Return y." condition? y))
            (/ x)))
        '(0 1 2)))</code></pre>
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -117,27 +117,6 @@ which implement interactive restarts.</p>
 
 <h2 id="issues">Issues</h2>
 
-<p>Should we specify that restarters are identified by their tags, and
-how an implementation should handle restarters with identical tags?
-Consider this example:</p>
-
-<pre class="example"><code>(restarter-guard map
-  (((use xs) "Return xs." condition? xs))
-  (map (lambda (x)
-         (restarter-guard reciprocal
-           (((use y) "Return y." condition? y))
-           (/ x)))
-       '(0 1 2)))</code></pre>
-
-<p>When <code>(/ 0)</code> is evaluated, two restarters, both tagged
-<code>use</code>, are raised. An implementation could handle this
-situation in several ways. It might give the “nearest” (i.e. to the
-exception) restarter, in this case <code>reciprocal</code>, priority
-and ignore the “outer” restarter. Alternatively, an interactor might
-prompt the user to disambiguate their choice by providing a who field.
-(This is not a general solution, however, since the who fields might
-also be the same.)</p>
-
 <h2 id="rationale">Rationale</h2>
 
 <p>An effective and flexible system for gracefully handling and

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -158,7 +158,8 @@ system that the ability to <em>interactively</em> choose a method of
 recovery for a condition is useful.  This ability, built into the Common
 Lisp language, is one of the primary reasons for the power of Common Lisp
 development and debugging environments. In this SRFI, the interactivity
-is provided by an <dfn>interactor</dfn>, a kind of exception handler.</p>
+is provided by an <dfn>interactor procedure</dfn> that by default is
+provided by the implementation, but can be overridden by the user.</p>
 
 <h3 id="srfi-249">SRFI 249</h3>
 
@@ -360,11 +361,9 @@ the result is undefined.</p>
 
 <h4 id="interactors">Interactors</h4>
 
-<p>An <dfn>interactor</dfn> is an exception handler as described in
-<cite>R6RS</cite> §7.1. If it is passed a restarter
-or a compound condition with
-one or more restarter components, then the interactor presents
-these restarters to the user. The information presented should include
+<p>An <dfn>interactor</dfn> is a procedure of one argument, a list
+of restarters, which the interactor presents
+to the user. The information presented should include
 the tag, description, and formals of each restarter. The user
 then selects a restarter and provides any additional data which that
 restarter needs. Finally, the interactor invokes the chosen restarter.</p>
@@ -380,11 +379,28 @@ restarter’s invoker).</p>
 presented in examples throughout this document. These examples are
 non-normative.)</p>
 
-<p><code>(default-interactor</code> <var>condition</var><code>)</code></p>
+<p><code>current-interactor</code></p>
 
-<p>The system’s default interactive handler. This is an interactor
-as described above, and should be exposed to allow interactive restarts
-in user code.</p>
+<p>A <a href="https://srfi.schemers.org/srfi-39/">SRFI 39</a> parameter
+object whose value is an interactor procedure. An implementation should
+initialize <code>current-interactor</code> to a sensible default
+interactor.</p>
+
+<p><code>(with-interactor</code> <var>interactor</var>
+<var>thunk</var><code>)</code></p>
+
+<p>Returns the results of invoking <var>thunk</var>. A new current
+exception handler is installed for the dynamic extent (as determined by
+<code>dynamic-wind</code>) of the invocation of <var>thunk</var>. If a
+restartable condition is raised in this extent, the handler invokes
+<var>interactor</var> on the list of available restarters provided by
+that condition.</p>
+
+<p><code>(with-current-interactor</code> <var>thunk</var><code>)</code></p>
+
+<p>Equivalent to</p>
+
+<pre class="example"><code>(with-interactor (current-interactor) <var>thunk</var>)</code></pre>
 
 <!-- Syntax section -->
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -518,7 +518,7 @@ violation occurs.</p>
 <p><var class="syn">expr</var> must evaluate to a procedure. The
 <code>restartable</code> form establishes (as if with
 <a href="#restarter-guard"><code>restarter-guard</code></a>) a
-restater with tag
+restarter with tag
 <code>use-arguments</code> for the
 dynamic extent of this procedure’s invocation. If an assertion
 violation (an exception raising a condition having type

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -404,8 +404,8 @@ form:</p>
    (lambda ()
      (cond ((procedure? obj)
             (parameterize ((current-interactor my-custom-interactor))
-              EX1 EX2 ...))  ; use my-custom-interactor
-           (else EY1 EY2 ...))))) ; use the default interactor</code></pre>
+              ...))  ; use my-custom-interactor
+           (else ...))))) ; use the default interactor</code></pre>
 
 <!-- Syntax section -->
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -245,9 +245,8 @@ types <code>&amp;who</code> or <code>&amp;message</code>.</p>
 
 <p>Usually, restarters and their handlers will be constructed
 implicitly by the high-level forms described in the
-<a href="#syntax">Syntax</a> section. Restarters and restarter handlers
-<!-- What is a restarter handler? -->
-must obey the following protocol:</p>
+<a href="#syntax">Syntax</a> section. Restarters and handlers that
+invoke them must obey the following protocol:</p>
 
 <ul>
   <li>

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -385,21 +385,29 @@ object whose value is an interactor procedure. An implementation should
 initialize <code>current-interactor</code> to a sensible default
 interactor.</p>
 
-<p><code>(with-interactor</code> <var>interactor</var>
-<var>thunk</var><code>)</code></p>
+<p><code>(with-current-interactor</code> <var>thunk</var><code>)</code></p>
 
 <p>Returns the results of invoking <var>thunk</var>. A new current
 exception handler is installed for the dynamic extent (as determined by
 <code>dynamic-wind</code>) of the invocation of <var>thunk</var>. If a
-restartable condition is raised in this extent, the handler invokes
-<var>interactor</var> on the list of available restarters provided by
-that condition.</p>
+restartable condition is raised in this extent, the handler evaluates
+<code>(current-interactor)</code> and applies the result to
+the list of available restarters provided by that condition.</p>
 
-<p><code>(with-current-interactor</code> <var>thunk</var><code>)</code></p>
+<p>Note that, since the current interactor is retrieved after an
+exception occurs and not when <code>with-current-interactor</code>
+is called, <var>thunk</var> may install new interactors dynamically.
+In the following, for example, a custom interactor is used to
+restart exceptions raised by one branch of the <code>cond</code>
+form:</p>
 
-<p>Equivalent to</p>
-
-<pre class="example"><code>(with-interactor (current-interactor) <var>thunk</var>)</code></pre>
+<pre class="example"><code>(define (foo obj)
+  (with-current-interactor
+   (lambda ()
+     (cond ((procedure? obj)
+            (parameterize ((current-interactor my-custom-interactor))
+              EX1 EX2 ...))  ; use my-custom-interactor
+           (else EY1 EY2 ...))))) ; use the default interactor</code></pre>
 
 <!-- Syntax section -->
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -385,12 +385,13 @@ object whose value is an interactor procedure.</p>
 
 <p><code>(with-current-interactor</code> <var>thunk</var><code>)</code></p>
 
-<p>Returns the results of invoking <var>thunk</var>. A new current
+<p>Returns the results of invoking <var>thunk</var>. An
 exception handler is installed for the dynamic extent (as determined by
-<code>dynamic-wind</code>) of the invocation of <var>thunk</var>. If a
-restartable condition is raised in this extent, the handler evaluates
+<code>dynamic-wind</code>) of the invocation of <var>thunk</var>. If this
+handler is passed a condition with type <code>&amp;restarter</code>,
+then it evaluates
 <code>(current-interactor)</code> and applies the result to
-the list of available restarters provided by that condition.</p>
+a list of that condition’s restarters.</p>
 
 <p>Note that, since the current interactor is retrieved after an
 exception occurs and not when <code>with-current-interactor</code>

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -118,11 +118,6 @@ which implement interactive restarts.</p>
 
 <h2 id="issues">Issues</h2>
 
-<p>Should <code>restarter-guard</code> provide a way to
-control which kinds of conditions can be restarted? Currently,
-<code>restarter-guard</code> is specified to restart any exception
-that occurs.</p>
-
 <p>Should we specify that restarters are identified by their tags, and
 how an implementation should handle restarters with identical tags?
 Consider this example:</p>

--- a/srfi/:255.sls
+++ b/srfi/:255.sls
@@ -38,7 +38,6 @@
           restartable
           restart
           current-interactor
-          with-interactor
           with-current-interactor
           )
 

--- a/srfi/:255.sls
+++ b/srfi/:255.sls
@@ -37,7 +37,9 @@
           restarter-guard
           restartable
           restart
-          default-interactor
+          current-interactor
+          with-interactor
+          with-current-interactor
           )
 
   (import (srfi :255 restarters)))

--- a/srfi/:255/restarters.sls
+++ b/srfi/:255/restarters.sls
@@ -113,6 +113,11 @@
     ;; Table associating restarter tags with restarters. If there
     ;; are multiple restarters with the same tag, the first (by
     ;; index in *restarters*) takes priority.
+    ;;
+    ;; This is a quick-and-dirty way to handle the general problem
+    ;; of duplicated restarter tags. A more sophisticated interactor
+    ;; might allow the user to disambiguate their choice using the
+    ;; restarter's "who" field, or perhaps an index number.
     (define restarters-by-tag
       (let ((table (make-eqv-hashtable (length restarters))))
         (for-each (lambda (r)

--- a/srfi/:255/restarters.sls
+++ b/srfi/:255/restarters.sls
@@ -38,7 +38,6 @@
           restarter-guard
           restartable
           current-interactor
-          with-interactor
           with-current-interactor
           )
 
@@ -91,24 +90,22 @@
   (define current-interactor
     (make-parameter (make-default-interactor 0)))
 
-  (define (with-interactor interactor thunk)
+  (define (with-current-interactor thunk)
     (with-exception-handler
      (lambda (obj)
        (if (restarter? obj)
            (let ((restarters
-                  (filter restarter? (simple-conditions obj))))
+                  (filter restarter? (simple-conditions obj)))
+                 (interactor (current-interactor)))
              (interactor restarters)
              (raise
               (condition
-               (make-who-condition 'with-interactor)
+               (make-who-condition 'with-current-interactor)
                (make-message-condition "interactor returned")
                (make-irritants-condition (list interactor restarters))
                (make-non-continuable-violation))))
             (raise-continuable obj)))
      thunk))
-
-  (define (with-current-interactor thunk)
-    (with-interactor (current-interactor) thunk))
 
   ;; Show the interactive user the available restarts, prompt for
   ;; a selection "command-line" and try to run it.

--- a/srfi/:255/restarters.sls
+++ b/srfi/:255/restarters.sls
@@ -126,9 +126,8 @@
     ;; Try to run the restarter selected by the user on the
     ;; values of the provided arguments.
     (define (invoke-selection choice)
-      (with-interactor
-       (make-default-interactor (+ level 1))
-       (lambda ()
+      (parameterize ((current-interactor
+                      (make-default-interactor (+ level 1))))
          (restarter-guard default-interactor
                           (interaction-con
                            ((retry)
@@ -146,8 +145,10 @@
                       (apply restart r vals))))
                  (else (error 'default-interactor
                               "invalid restarter choice"
-                              choice)))))))
+                              choice))))))
 
+    (with-current-interactor
+     (lambda ()
     (display "Restartable exception occurred.\n")
     (let-values (((_ks urs) (hashtable-entries restarters-by-tag)))
       (show-restarters (vector->list urs)))
@@ -163,7 +164,7 @@
                         (display v)
                         (newline))
                       vals))
-          (loop)))))
+          (loop)))))))
 
   ;; Print a list of restarters.
   (define (show-restarters restarters)

--- a/tests/test-chez.scm
+++ b/tests/test-chez.scm
@@ -2,6 +2,7 @@
 ;;; SPDX-License-Identifier: MIT
 
 (import (rnrs)
+        (srfi :39)
         (srfi :64)
         (srfi :255)
         (only (chezscheme) include))

--- a/tests/test-guile.scm
+++ b/tests/test-guile.scm
@@ -6,6 +6,7 @@
   (default-duplicate-binding-handler '(last)))
 
 (import (rnrs)
+        (srfi srfi-39)
         (srfi srfi-64)
         (srfi srfi-255)
         (only (guile) include))

--- a/tests/test-restarters.scm
+++ b/tests/test-restarters.scm
@@ -214,6 +214,20 @@
                         (list x rest))))
      0))))
 
+(test-equal "with-interactor 1"
+ 10
+ (with-interactor
+  (lambda (restarters)
+    (let ((use (find (lambda (r)
+                       (eqv? (restarter-tag r) 'use-value))
+                     restarters)))
+      (when use
+        (restart use 10))))
+  (lambda ()
+    (restarter-guard foo
+     (con ((use-value x) "return a value" condition? x))
+     (assertion-violation 'foo "bad")))))
+
 (test-end)
 
 (exit (test-runner-fail-count (test-runner-current)))

--- a/tests/test-restarters.scm
+++ b/tests/test-restarters.scm
@@ -214,19 +214,23 @@
                         (list x rest))))
      0))))
 
-(test-equal "with-interactor 1"
- 10
- (with-interactor
-  (lambda (restarters)
-    (let ((use (find (lambda (r)
-                       (eqv? (restarter-tag r) 'use-value))
-                     restarters)))
-      (when use
-        (restart use 10))))
+(test-equal "with-current-interactor"
+ 0
+ (with-current-interactor
   (lambda ()
-    (restarter-guard foo
-     (con ((use-value x) "return a value" condition? x))
-     (assertion-violation 'foo "bad")))))
+    (parameterize ((current-interactor
+                    (lambda (rs)
+                      (let ((r (find (lambda (r)
+                                       (eqv? (restarter-tag r)
+                                             'return-zero))
+                                     rs)))
+                        (and r (restart r))))))
+      (restarter-guard somewhere
+       (con ((return-zero)
+              "return zero"
+              assertion-violation?
+              0))
+       (assertion-violation 'somewhere "bad"))))))
 
 (test-end)
 


### PR DESCRIPTION
This draft returns, more or less, to the interactor model of SRFI 249. In particular, the ‘current-interactor’ parameter is back, and can be used to dynamically install custom interactors. A number of confusing or awkward parts of the SRFI have also been improved (I hope).