### PR TITLE
Clarification

### DIFF
--- a/srfi-255.html
+++ b/srfi-255.html
@@ -361,7 +361,8 @@ exception handler is installed for the dynamic extent (as determined by
 handler is passed a condition with type <code>&amp;restarter</code>,
 then it evaluates
 <code>(current-interactor)</code> and applies the result to
-a list of that condition’s restarters.</p>
+a list of that condition’s restarters. Non-restarter conditions are
+re-raised.</p>
 
 <p>Note that, since the current interactor is retrieved after an
 exception occurs and not when <code>with-current-interactor</code>

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -362,7 +362,7 @@ handler is passed a condition with type <code>&amp;restarter</code>,
 then it evaluates
 <code>(current-interactor)</code> and applies the result to
 a list of that condition’s restarters. Non-restarter conditions are
-re-raised.</p>
+re-raised with <code>raise-continuable</code>.</p>
 
 <p>Note that, since the current interactor is retrieved after an
 exception occurs and not when <code>with-current-interactor</code>


### PR DESCRIPTION
This adds a sentence clarifying `with-current-interactor`'s behavior when non-restarter conditions are raised.

Arthur, do you consider this a draft-worthy change?
