### PR TITLE
Draft #8 of SRFI 255

### DIFF
--- a/srfi-255.html
+++ b/srfi-255.html
@@ -292,6 +292,17 @@ the condition types <code>&amp;who</code> or
 
 <h5>Example:</h5>
 
+<p>The following example defines a simple restartable version of the
+<code>/</code> procedure. If <code>/</code> raises any condition, then
+<code>safe-/</code> compounds that condition with a
+<a href="#use-arguments"><code>use-arguments</code></a> restarter and
+re-raises it.</p>
+
+<p>(This is not the recommended way of defining restartable procedures,
+but is included as an example of building and installing restarters
+“by hand”. <a href="#define-restartable"><code>define-restartable</code></a>
+provides a much more compact syntax for the same thing.)</p>
+
 <pre class="example"><code>(define (safe-/ x y)
   (call/cc
    (lambda (return-value)
@@ -559,26 +570,25 @@ restart[0]&gt;</code> <samp>(use-arguments 3)</samp>
 ;; user to provide a list to return as the value of the whole
 ;; 'map-restartable' computation, while the second re-invokes
 ;; *proc* with new arguments.
-(define (map-restartable proc-who proc lis)
+(define (map-restartable proc lis)
   (restarter-guard map-restartable
     (mcon ((use-list new-lis)
            "Return new-lis as the value of map-restartable."
            serious-condition?
            (assert (list? new-lis))
            new-lis))
-    (map (restartable proc-who proc) lis)))
+    (map (restartable "[mapped procedure]" proc) lis)))
 
 &gt;</code> <samp>(with-current-interactor
    (lambda ()
-     (map-restartable "divider"
-                      (lambda (x) (/ 10 x)))
+     (map-restartable (lambda (x) (/ 10 x)))
                       '(1 2 0 4))))</samp>
 
 <code>Restartable exception occurred.
 Who: /
 Message: undefined for 0
 Irritants: (0)
-(use-arguments . args) [divider]: Apply the procedure to new arguments.
+(use-arguments . args) [[mapped procedure]]: Apply the procedure to new arguments.
 (use-list new-lis) [map-restartable]: Return new-lis as the value of map-restartable.
 restart[0]&gt;</code> <samp>(use-list '(#f))</samp>
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -408,7 +408,8 @@ handler is passed a condition with type <code>&amp;restarter</code>,
 then it evaluates
 <code>(current-interactor)</code> and applies the result to that
 condition. Non-restarter conditions are
-re-raised with <code>raise-continuable</code>.</p>
+re-raised with <code>raise-continuable</code>. If the interactor returns,
+then a non-continuable exception is raised.</p>
 
 <p>Note that, since the current interactor is retrieved after an
 exception occurs and not when <code>with-current-interactor</code>

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -305,14 +305,15 @@ provides a much more compact syntax for the same thing.)</p>
 
 <pre class="example"><code>(define (safe-/ x y)
   (call/cc
-   (lambda (return-value)
+   (lambda (return)
      (let ((val-restarter
-            (make-restarter 'return-value
-                            "Return x."
+            (make-restarter 'use-arguments
+                            "Apply procedure to new arguments."
                             'safe-/
-                            '(x)
+                            '(x y)
                             condition?
-                            return-value)))
+                            (lambda (x y)
+                              (return (safe-/ x y))))))
        (with-exception-handler
         (lambda (con)
           (raise-continuable
@@ -328,8 +329,8 @@ Restartable exception occurred.
 Who: /
 Message: undefined for 0
 Irritants: (0)
-(return-value x) [safe-/]: Return x.
-restart[0]&gt; <samp>(return-value 4)</samp>
+(use-arguments x y) [safe-/]: Apply procedure to new arguments.
+restart[0]&gt; <samp>(use-arguments 8 2)</samp>
 
   ⇒ 4</code></pre>
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -325,6 +325,9 @@ provides a much more compact syntax for the same thing.)</p>
    (lambda () (safe-/ 1 0)))</samp>
 
 Restartable exception occurred.
+Who: /
+Message: undefined for 0
+Irritants: (0)
 (return-value x) [safe-/]: Return x.
 restart[0]&gt; <samp>(return-value 4)</samp>
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -359,10 +359,13 @@ the result is undefined.</p>
 
 <h4 id="interactors">Interactors</h4>
 
-<p>An <dfn>interactor</dfn> is a procedure of one argument, a list
-of restarters, which the interactor presents
-to the user. The information presented should include
-the tag, description, and formals of each restarter. The user
+<p>An <dfn>interactor</dfn> is a procedure that accepts a single
+(usually composite) restarter object.
+The interactor presents the restarters of
+this object to the user. The information presented should include
+the tag, description, who, and formals of each restarter, and may also
+include information from other components (e.g. messages and irritants)
+of the condition argument. The user
 then selects a restarter and provides any additional data which that
 restarter needs. Finally, the interactor invokes the chosen restarter.</p>
 
@@ -389,8 +392,8 @@ exception handler is installed for the dynamic extent (as determined by
 <code>dynamic-wind</code>) of the invocation of <var>thunk</var>. If this
 handler is passed a condition with type <code>&amp;restarter</code>,
 then it evaluates
-<code>(current-interactor)</code> and applies the result to
-a list of that condition’s restarters. Non-restarter conditions are
+<code>(current-interactor)</code> and applies the result to that
+condition. Non-restarter conditions are
 re-raised with <code>raise-continuable</code>.</p>
 
 <p>Note that, since the current interactor is retrieved after an

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -499,6 +499,9 @@ of the <code>restarter-guard</code> expression.</p>
    (lambda () (safe-/ 1 0)))</samp>
 
 Restartable exception occurred.
+Who: /
+Message: undefined for 0
+Irritants: (0)
 (return-value v) [safe-/]: Return a specific value.
 (return-numerator) [safe-/]: Return the numerator.
 (return-zero) [safe-/]: Return zero.
@@ -544,6 +547,9 @@ of the restarter is filled by <var class="syn">who</var>.</p>
           '(1 2 0 4))))</samp>
 
 <code>Restartable exception occurred.
+Who: /
+Message: undefined for 0
+Irritants: (0)
 (use-arguments . args) [divider]: Apply the procedure to new arguments.
 restart[0]&gt;</code> <samp>(use-arguments 3)</samp>
 
@@ -569,6 +575,9 @@ restart[0]&gt;</code> <samp>(use-arguments 3)</samp>
                       '(1 2 0 4))))</samp>
 
 <code>Restartable exception occurred.
+Who: /
+Message: undefined for 0
+Irritants: (0)
 (use-arguments . args) [divider]: Apply the procedure to new arguments.
 (use-list new-lis) [map-restartable]: Return new-lis as the value of map-restartable.
 restart[0]&gt;</code> <samp>(use-list '(#f))</samp>
@@ -582,6 +591,9 @@ restart[0]&gt;</code> <samp>(use-list '(#f))</samp>
                       '(1 2 0 4))))</samp>
 
 <code>Restartable exception occurred.
+Who: /
+Message: undefined for 0
+Irritants: (0)
 (use-arguments . args) [divider]: Apply the procedure to new arguments.
 (use-list new-lis) [map-restartable]: Return new-lis as the value of map-restartable.
 restart[0]&gt;</code> <samp>(use-arguments -1)</samp>
@@ -638,6 +650,9 @@ forms:</p>
    (lambda () (safe-/ 4 0)))</samp>
 
 <code>Restartable exception occurred.
+Who: /
+Message: undefined for 0
+Irritants: (0)
 (use-arguments x y) [safe-/]: Apply the procedure to new arguments.
 restart[0]&gt;</code> <samp>(use-arguments 4 2)</samp>
 

--- a/srfi/:255/restarters.sls
+++ b/srfi/:255/restarters.sls
@@ -154,22 +154,22 @@
 
     (with-current-interactor
      (lambda ()
-    (display "Restartable exception occurred.\n")
-    (let-values (((_ks urs) (hashtable-entries restarters-by-tag)))
-      (show-restarters (vector->list urs)))
-    (let loop ()  ; prompt loop
-      (display "restart [")
-      (display level)
-      (display "]> ")
-      (let ((choice (read)))
-        (when (eof-object? choice) (abort))  ; TODO: Improve behavior
-        (let-values ((vals (invoke-selection choice)))
-          (unless (null? vals)
-            (for-each (lambda (v)
-                        (display v)
-                        (newline))
-                      vals))
-          (loop)))))))
+       (display "Restartable exception occurred.\n")
+       (let-values (((_ks urs) (hashtable-entries restarters-by-tag)))
+         (show-restarters (vector->list urs)))
+       (let loop ()  ; prompt loop
+         (display "restart [")
+         (display level)
+         (display "]> ")
+         (let ((choice (read)))
+           (when (eof-object? choice) (abort))  ; TODO: Improve behavior
+           (let-values ((vals (invoke-selection choice)))
+             (unless (null? vals)
+               (for-each (lambda (v)
+                           (display v)
+                           (newline))
+                         vals))
+             (loop)))))))
 
   ;; Print a list of restarters.
   (define (show-restarters restarters)

--- a/tests/test-restarters.scm
+++ b/tests/test-restarters.scm
@@ -134,11 +134,12 @@
  (guard (con
          ((assertion-violation? con) 0))
    (parameterize ((current-interactor
-                   (lambda (rs)
-                     (let ((r (find (lambda (r)
-                                      (eqv? (restarter-tag r)
-                                            'return-1))
-                                    rs)))
+                   (lambda (con)
+                     (let ((r (find (lambda (c)
+                                      (and (restarter? c)
+                                           (eqv? (restarter-tag r)
+                                                 'return-1)))
+                                    (simple-conditions con))))
                        (and r (restart r))))))
      (with-current-interactor
       (lambda ()
@@ -228,11 +229,12 @@
  (with-current-interactor
   (lambda ()
     (parameterize ((current-interactor
-                    (lambda (rs)
-                      (let ((r (find (lambda (r)
-                                       (eqv? (restarter-tag r)
-                                             'return-zero))
-                                     rs)))
+                    (lambda (con)
+                      (let ((r (find (lambda (c)
+                                       (and (restarter? c)
+                                            (eqv? (restarter-tag c)
+                                                  'return-zero)))
+                                     (simple-conditions con))))
                         (and r (restart r))))))
       (restarter-guard somewhere
        (con ((return-zero)


### PR DESCRIPTION
I've generalized interactor procedures to take a condition object, rather than a list of restarters (as they do in SRFI 249). This gives interactors access to the condition raised by the triggering exception, which may include important information (e.g. message, who, and irritants data). In the old model, this information was filtered out. Thanks to Arthur A. Gleckler for pointing out this limitation.

The relationship between old- and new-style interactors is pretty simple, and is given by the following two conversion functions:

```
(define (to-new-style-interactor interactor)
  (lambda (con)
    (interactor (filter restarter? (simple-conditions con)))))

(define (to-old-style-interactor interactor)
  (lambda (restarters)
    (interactor (apply condition restarters))))
```
I've also changed the implementation of the sample interactor so that the message, who, and irritants data of the passed condition are displayed, if they are present.
