### PR TITLE
Draft #9 of SRFI 255

### DIFF
--- a/srfi-255.html
+++ b/srfi-255.html
@@ -654,17 +654,17 @@ restart[0]&gt;</code> <samp>(use-arguments 4 2)</samp>
 that the last expression in a <var class="syn">body</var> occur in a
 tail context (see <cite>R7RS</cite> §3.5). This may be difficult or
 impossible in R6RS or R7RS Scheme, since the <var>thunk</var> argument
-of the <code>with-exception-handler</code> primitive does not necessarily
-occur in a tail context.</p>
+of the <code>with-exception-handler</code> primitive may not occur in
+a tail context.</p>
 
-<p>Even if restartable procedures are implemented to give proper
-tail-calls, a recursive restartable procedure will still accumulate
-context in the form of additional handlers. (This problem afflicts
-all recursive Scheme procedures which call themselves after
-installing an exception handler.) Users are advised to enclose
-recursive computations (using <code>letrec</code>, etc.) within
-restarter forms, rather than writing restartable procedures that
-call themselves.</p>
+<p>Even if these forms are implemented to give proper tail-calls,
+a recursive procedure guarded with restarters may still accumulate
+context in the form of additional handlers. (This problem afflicts all
+recursive Scheme procedures which call themselves after installing an
+exception handler.) Users are advised to enclose recursive computations
+(using <code>letrec</code>, etc.) within restarter forms, rather than
+writing restartable procedures that call themselves, or that contain
+self-calls wrapped in a <code>restarter-guard</code> form.</p>
 
 <!-- Standard restart tags section -->
 

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -309,8 +309,7 @@ provides a much more compact syntax for the same thing.)</p>
                con)))
         (lambda () (/ x y)))))))
 
-&gt; <samp>(with-current-interactor
-   (lambda () (safe-/ 1 0)))</samp>
+&gt; <samp>(safe-/ 1 0)</samp>
 
 Restartable exception occurred.
 Who: /
@@ -492,8 +491,7 @@ of the <code>restarter-guard</code> expression.</p>
           0))
     (/ a b)))
 
-&gt; <samp>(with-current-interactor
-   (lambda () (safe-/ 1 0)))</samp>
+&gt; <samp>(safe-/ 1 0)</samp>
 
 Restartable exception occurred.
 Who: /
@@ -538,10 +536,8 @@ of the restarter is filled by <var class="syn">who</var>.</p>
 
 <h5>Examples:</h5>
 
-<pre class="example"><code>&gt;</code> <samp>(with-current-interactor
-   (lambda ()
-     (map (restartable "divider" (lambda (x) (/ 10 x)))
-          '(1 2 0 4))))</samp>
+<pre class="example"><code>&gt;</code> <samp>(map (restartable "divider" (lambda (x) (/ 10 x)))
+       '(1 2 0 4))</samp>
 
 <code>Restartable exception occurred.
 Who: /
@@ -565,10 +561,8 @@ restart[0]&gt;</code> <samp>(use-arguments 3)</samp>
            new-lis))
     (map (restartable "[mapped procedure]" proc) lis)))
 
-&gt;</code> <samp>(with-current-interactor
-   (lambda ()
-     (map-restartable (lambda (x) (/ 10 x)))
-                      '(1 2 0 4))))</samp>
+&gt;</code> <samp>(map-restartable (lambda (x) (/ 10 x))
+                   '(1 2 0 4))</samp>
 
 <code>Restartable exception occurred.
 Who: /
@@ -580,11 +574,9 @@ restart[0]&gt;</code> <samp>(use-list '(#f))</samp>
 
   ⇒ (#f)
 
-<code>&gt;</code> <samp>(with-current-interactor
-   (lambda ()
-     (map-restartable "divider"
-                      (lambda (x) (/ 10 x)))
-                      '(1 2 0 4))))</samp>
+<code>&gt;</code> <samp>(map-restartable "divider"
+                   (lambda (x) (/ 10 x))
+                   '(1 2 0 4))</samp>
 
 <code>Restartable exception occurred.
 Who: /
@@ -642,8 +634,7 @@ forms:</p>
 <pre class="example"><code>(define-restartable (safe-/ x y)
   (/ x y))
 
-&gt;</code> <samp>(with-current-interactor
-   (lambda () (safe-/ 4 0)))</samp>
+&gt;</code> <samp>(safe-/ 4 0)</samp>
 
 <code>Restartable exception occurred.
 Who: /

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -119,6 +119,7 @@
           <li><a href="#ignore"><code>ignore</code></a></li>
           <li><a href="#retry"><code>retry</code></a></li>
           <li><a href="#use-arguments"><code>use-arguments</code></a></li>
+          <li><a href="#raise"><code>raise</code></a></li>
         </ul>
       </li>
     </ul>
@@ -676,6 +677,11 @@ when naming their restarters.</p>
   The invoker of a <code>use-arguments</code> restarter accepts zero
   or more arguments. This is the tag protocol used by
   <code>restartable</code> and <code>define-restartable</code>.</dd>
+
+  <dt class="tag-name" id="raise">raise</dt>
+  <dd>Invokes <code>raise</code> on the original triggering condition,
+  aborting the pending restart. The invoker of a <code>raise</code>
+  restarter accepts zero arguments.</dd>
 </dl>
 
 <!-- Implementation section -->

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -111,8 +111,7 @@
               <li><a href="#define-restartable"><code>define-restartable</code></a></li>
             </ul>
           </li>
-          <li><a href="#tail-calls">Tail calls and restartable
-            procedures</a></li>
+          <li><a href="#tail-calls">Tail calls and restarters</a></li>
         </ul>
       </li>
       <li><a href="#standard-restart-tags">Proposed standard restart tags</a>
@@ -648,7 +647,7 @@ restart[0]&gt;</code> <samp>(use-arguments 4 2)</samp>
 
   <code>⇒ 2</code></pre>
 
-<h4 id="tail-calls">Tail calls and restartable procedures</h4>
+<h4 id="tail-calls">Tail calls and restarters</h4>
 
 <p>In the above forms, it is recommended that implementers ensure
 that the last expression in a <var class="syn">body</var> occur in a

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -629,6 +629,10 @@ forms:</p>
   </li>
 </ul>
 
+<p>It is recommended that implementations ensure that the last expression
+within the <var class="syn">body</var> of a <code>define-restartable</code>
+form occurs in a tail context (see <cite>R7RS</cite> §3.5).</p>
+
 <h5>Example:</h5>
 
 <pre class="example"><code>(define-restartable (safe-/ x y)

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -118,9 +118,9 @@
         <ul>
           <li><a href="#abort"><code>abort</code></a></li>
           <li><a href="#ignore"><code>ignore</code></a></li>
+          <li><a href="#raise"><code>raise</code></a></li>
           <li><a href="#retry"><code>retry</code></a></li>
           <li><a href="#use-arguments"><code>use-arguments</code></a></li>
-          <li><a href="#raise"><code>raise</code></a></li>
         </ul>
       </li>
     </ul>
@@ -681,6 +681,11 @@ when naming their restarters.</p>
   <dd>Ignores the condition and proceeds. The invoker of an
   <code>ignore</code> restarter accepts zero arguments.</dd>
 
+  <dt class="tag-name" id="raise">raise</dt>
+  <dd>Invokes <code>raise</code> on the original triggering condition,
+  aborting the pending restart. The invoker of a <code>raise</code>
+  restarter accepts zero arguments.</dd>
+
   <dt class="tag-name" id="retry">retry</dt>
   <dd>Simply retries a whole computation from a certain point, with no
   explicitly altered inputs. Some implicit environmental changes are
@@ -692,11 +697,6 @@ when naming their restarters.</p>
   The invoker of a <code>use-arguments</code> restarter accepts zero
   or more arguments. This is the tag protocol used by
   <code>restartable</code> and <code>define-restartable</code>.</dd>
-
-  <dt class="tag-name" id="raise">raise</dt>
-  <dd>Invokes <code>raise</code> on the original triggering condition,
-  aborting the pending restart. The invoker of a <code>raise</code>
-  restarter accepts zero arguments.</dd>
 </dl>
 
 <!-- Implementation section -->

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -86,7 +86,6 @@
           <li><a href="#restarter-tag"><code>restarter-tag</code></a></li>
           <li><a href="#restarter-description"><code>restarter-description</code></a></li>
           <li><a href="#restarter-who"><code>restarter-who</code></a></li>
-          <li><a href="#restarter-condition-predicate"><code>restarter-condition-predicate</code></a></li>
           <li><a href="#restarter-formals"><code>restarter-formals</code></a></li>
           <li><a href="#restart"><code>restart</code></a></li>
           <li><a href="#interactors">Interactors</a>
@@ -204,7 +203,7 @@ in the Scheme Reports: names such as <var>symbol</var>,
 <p>A <dfn>restarter</dfn> is a condition object (see the <cite>R6RS
 standard libraries</cite> document, Section 7.2) of type
 <code>&amp;restarter</code>.
-It has five fields:</p>
+It has the following fields:</p>
 
 <dl>
   <dt>tag</dt>
@@ -224,11 +223,6 @@ It has five fields:</p>
   4.1.4 of <cite>R7RS Small</cite>, describing the arguments expected by the
   restarter’s <var>invoker</var>.</dd>
 
-  <dt id="condition-predicate">condition-predicate</dt>
-  <dd>A procedure which returns true when applied to a condition object
-  <var>c</var> when the restarter can be used to restart the computation
-  that raised <var>c</var>. Otherwise, it returns <code>#f</code>.</dd>
-
   <dt>invoker</dt>
   <dd>A procedure that actually performs the recovery. It must not
   return. The number of arguments it expects is given by
@@ -243,7 +237,6 @@ It has five fields:</p>
   (description restarter-description)
   (who restarter-who)
   (formals restarter-formals)
-  (condition-predicate restarter-condition-predicate)
   (invoker restarter-invoker))</code></pre>
 
 <p>A restarter’s fields
@@ -264,11 +257,6 @@ invoke them must obey the following protocol:</p>
     composite condition (see Section 7.2.1 of the <cite>R6RS</cite>) including the
     object raised by the triggering exception as one of its components.</p>
   </li>
-  <li>
-    <p>A handler must not invoke a restarter if the object
-    raised by the triggering exception does not satisfy that restarter’s
-    condition predicate.</p>
-  </li>
 </ul>
 
 <!-- Procedures section -->
@@ -276,7 +264,7 @@ invoke them must obey the following protocol:</p>
 <h3 id="procedures">Procedures</h3>
 
 <p id="make-restarter"><code>(make-restarter</code> <var>tag</var> <var>description</var>
-<var>who</var> <var>formals</var> <var>condition-predicate</var>
+<var>who</var> <var>formals</var>
 <var>invoker</var><code>)</code> →
 <span class="type-meta">restarter</span></p>
 
@@ -311,13 +299,12 @@ provides a much more compact syntax for the same thing.)</p>
                             "Apply procedure to new arguments."
                             'safe-/
                             '(x y)
-                            condition?
                             (lambda (x y)
                               (return (safe-/ x y))))))
        (with-exception-handler
         (lambda (con)
           (raise-continuable
-           (if ((restarter-condition-predicate val-restarter) con)
+           (if (condition? con)
                (condition con val-restarter)
                con)))
         (lambda () (/ x y)))))))
@@ -349,14 +336,10 @@ restart[0]&gt; <samp>(use-arguments 8 2)</samp>
 <code id="restarter-who">(restarter-who</code> <var>restarter</var><code>)</code> →
 <span class="type-meta">symbol-or-string</span><br>
 
-<code id="restarter-condition-predicate">(restarter-condition-predicate</code>
-<var>restarter</var><code>)</code> →
-<span class="type-meta">procedure</span><br>
-
 <code id="restarter-formals">(restarter-formals</code> <var>restarter</var><code>)</code> →
 <span class="type-meta">pair-or-symbol</span></p>
 
-<p>Returns the tag / description / who / condition predicate /
+<p>Returns the tag / description / who /
 formals of <var>restarter</var>.
 The effect of mutating the values returned by these procedures is
 undefined.</p>
@@ -467,7 +450,7 @@ appears in more than one clause.</p>
 <h5>Semantics:</h5>
 
 <p>First, the <var class="syn">pred-expression</var>s are evaluated
-to <a href="#condition-predicate">condition predicates</a> in an
+in an
 unspecified order. Then, an exception handler
 is installed for the dynamic extent (as
 determined by <code>dynamic-wind</code>) of the invocation of
@@ -475,15 +458,13 @@ determined by <code>dynamic-wind</code>) of the invocation of
 constructs a compound restarter condition, which includes the condition
 raised by the triggering exception and
 restarters constructed from the <var class="syn">restarter-clauses</var>,
-and raises it with <code>raise-continuable</code>. Only restarters
-whose condition predicates return true when applied to the raised
-condition are included.</p>
+and raises it with <code>raise-continuable</code>. A restarter is only
+added if the condition predicate of its clause returns true when applied
+to the raised condition.</p>
 
 <p>The who field of each restarter constructed from
 <var class="syn">restarter-clauses</var> is initialized to
-<var class="syn">who</var>, and
-the condition-predicate field to the value of
-<var class="syn">pred-expression</var>.
+<var class="syn">who</var>.
 Each invoker procedure is constructed from a
 <var class="syn">formals</var> and a <var class="syn">restarter-body</var>.
 If <var class="syn">condition-var</var> was provided, then the condition

--- a/srfi-255.html
+++ b/srfi-255.html
@@ -111,6 +111,8 @@
               <li><a href="#define-restartable"><code>define-restartable</code></a></li>
             </ul>
           </li>
+          <li><a href="#tail-calls">Tail calls and restartable
+            procedures</a></li>
         </ul>
       </li>
       <li><a href="#standard-restart-tags">Proposed standard restart tags</a>
@@ -630,10 +632,6 @@ forms:</p>
   </li>
 </ul>
 
-<p>It is recommended that implementations ensure that the last expression
-within the <var class="syn">body</var> of a <code>define-restartable</code>
-form occurs in a tail context (see <cite>R7RS</cite> §3.5).</p>
-
 <h5>Example:</h5>
 
 <pre class="example"><code>(define-restartable (safe-/ x y)
@@ -649,6 +647,24 @@ Irritants: (0)
 restart[0]&gt;</code> <samp>(use-arguments 4 2)</samp>
 
   <code>⇒ 2</code></pre>
+
+<h4 id="tail-calls">Tail calls and restartable procedures</h4>
+
+<p>In the above forms, it is recommended that implementers ensure
+that the last expression in a <var class="syn">body</var> occur in a
+tail context (see <cite>R7RS</cite> §3.5). This may be difficult or
+impossible in R6RS or R7RS Scheme, since the <var>thunk</var> argument
+of the <code>with-exception-handler</code> primitive does not necessarily
+occur in a tail context.</p>
+
+<p>Even if restartable procedures are implemented to give proper
+tail-calls, a recursive restartable procedure will still accumulate
+context in the form of additional handlers. (This problem afflicts
+all recursive Scheme procedures which call themselves after
+installing an exception handler.) Users are advised to enclose
+recursive computations (using <code>letrec</code>, etc.) within
+restarter forms, rather than writing restartable procedures that
+call themselves.</p>
 
 <!-- Standard restart tags section -->
 

--- a/srfi/:255.sls
+++ b/srfi/:255.sls
@@ -31,7 +31,6 @@
           restarter-formals
           restarter-description
           restarter-invoker
-          restarter-condition-predicate
           restarter-who
           define-restartable
           restarter-guard

--- a/tests/test-restarters.scm
+++ b/tests/test-restarters.scm
@@ -62,7 +62,7 @@
      (lambda (con) (restart/tag 'use-value con #t))
      (lambda ()
        (raise-continuable
-        (make-restarter 'use-value "Return x." 'foo '(x) condition? k)))))))
+        (make-restarter 'use-value "Return x." 'foo '(x) k)))))))
 
 (test-assert "restarter objects 2"
  (call-with-current-continuation
@@ -75,7 +75,6 @@
                         "Return (not x)."
                         'foo
                         '(x)
-                        condition?
                         (lambda (x) (k (not x))))))))))
 
 (test-equal "restarter objects 3"
@@ -97,7 +96,6 @@
                             "Return restarter info as a list."
                             'foo
                             '()
-                            condition?
                             dump)))
 
          (raise-continuable r)))))))


### PR DESCRIPTION
This draft removes the restarter condition type's condition-predicate field, which was found to be unnecessary. It also adds some discussion of the issues that restarters pose for recursive procedures.

Thanks for merging!
